### PR TITLE
Support Alternate Domain in cloudfront by adding domain in hosted zone and generate certificate for tls

### DIFF
--- a/cdk/bin/bedrock-chat.ts
+++ b/cdk/bin/bedrock-chat.ts
@@ -73,6 +73,9 @@ const bedrockRegionResources = new BedrockRegionResourcesStack(
   }
 );
 
+const ALTERNATE_DOMAIN_NAME: string = app.node.tryGetContext("alternateDomainName");
+const HOSTED_ZONE_ID: string = app.node.tryGetContext("hostedZoneId");
+
 const chat = new BedrockChatStack(app, `BedrockChatStack`, {
   env: {
     // account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -96,6 +99,8 @@ const chat = new BedrockChatStack(app, `BedrockChatStack`, {
   useStandbyReplicas: USE_STAND_BY_REPLICAS,
   enableBedrockCrossRegionInference: ENABLE_BEDROCK_CROSS_REGION_INFERENCE,
   enableLambdaSnapStart: ENABLE_LAMBDA_SNAPSTART,
+  alternateDomainName: ALTERNATE_DOMAIN_NAME,
+  hostedZoneId: HOSTED_ZONE_ID,
 });
 chat.addDependency(waf);
 chat.addDependency(bedrockRegionResources);

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -70,6 +70,8 @@
     ],
     "enableRagReplicas": true,
     "enableBedrockCrossRegionInference": true,
-    "enableLambdaSnapStart": true
+    "enableLambdaSnapStart": true,
+    "alternateDomainName": "",
+    "hostedZoneId": ""
   }
 }

--- a/cdk/lib/bedrock-chat-stack.ts
+++ b/cdk/lib/bedrock-chat-stack.ts
@@ -40,6 +40,8 @@ export interface BedrockChatStackProps extends StackProps {
   readonly useStandbyReplicas: boolean;
   readonly enableBedrockCrossRegionInference: boolean;
   readonly enableLambdaSnapStart: boolean;
+  readonly alternateDomainName?: string;
+  readonly hostedZoneId?: string;
 }
 
 export class BedrockChatStack extends cdk.Stack {
@@ -124,6 +126,8 @@ export class BedrockChatStack extends cdk.Stack {
       webAclId: props.webAclId,
       enableMistral: props.enableMistral,
       enableIpV6: props.enableIpV6,
+      alternateDomainName: props.alternateDomainName,
+      hostedZoneId: props.hostedZoneId,
     });
 
     const auth = new Auth(this, "Auth", {


### PR DESCRIPTION
1. Add configuration to provide alternate domain in AWS Cloudfront
2. Modify frontend.ts code to configure the newly provided domain name in AWS Cloudfront and associate a certificate.
Create the provided record in the hosted zone
3. Generate a certificate for the newly created domain with DNS Challenge
