### PR TITLE
Reduced both grounding and relevance thresholds from 0.7 to 0

### DIFF
--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -130,8 +130,8 @@ const BotKbEditPage: React.FC = () => {
   const [sexualThreshold, setSexualThreshold] = useState<number>(2);
   const [violenceThreshold, setViolenceThreshold] = useState<number>(2);
   const [misconductThreshold, setMisconductThreshold] = useState<number>(2);
-  const [groundingThreshold, setGroundingThreshold] = useState<number>(0.7);
-  const [relevanceThreshold, setRelevanceThreshold] = useState<number>(0.7);
+  const [groundingThreshold, setGroundingThreshold] = useState<number>(0);
+  const [relevanceThreshold, setRelevanceThreshold] = useState<number>(0);
   const [guardrailArn, setGuardrailArn] = useState<string>('');
   const [guardrailVersion, setGuardrailVersion] = useState<string>('');
   const [parsingModel, setParsingModel] = useState<ParsingModel | undefined>(
@@ -561,12 +561,12 @@ const BotKbEditPage: React.FC = () => {
           setGroundingThreshold(
             bot.bedrockGuardrails.groundingThreshold
               ? bot.bedrockGuardrails.groundingThreshold
-              : 0.7
+              : 0
           );
           setRelevanceThreshold(
             bot.bedrockGuardrails.relevanceThreshold
               ? bot.bedrockGuardrails.relevanceThreshold
-              : 0.7
+              : 0
           );
           setParsingModel(bot.bedrockKnowledgeBase.parsingModel);
           setWebCrawlingScope(


### PR DESCRIPTION
Notes:
Algebra 2 Bot
Asked an out of scope question and a part of the response was blocked
Tested at 0.7 and 0.25 

Question:
What is the integral of 2x?

Example of a blocked response:
"Would you like help with any of those algebra 2 topics instead?this output message is blocked"