### PR TITLE
Persist lti session information in local storage

### DIFF
--- a/backend/app/routes/lti.py
+++ b/backend/app/routes/lti.py
@@ -117,17 +117,19 @@ async def lti_redirect(
         pem = jwk.construct(public_key).to_pem()
         options = {'verify_aud': False}
         decoded_token = jwt.decode(id_token, pem, options=options, issuer=CANVAS_ISSUER)
+        logger.info(f'Decoded token: {decoded_token}')
         
         # Extract claims
-        context = decoded_token.get('https://purl.imsglobal.org/spec/lti/claim/context', {})
-
+        course_name = decoded_token.get('https://purl.imsglobal.org/spec/lti/claim/context', {}).get('label', None)
         roles = decoded_token.get('https://purl.imsglobal.org/spec/lti/claim/roles', [])
         # remove prefix http://purl.imsglobal.org/vocab/lis/v2 from roles
         roles = [r.replace('http://purl.imsglobal.org/vocab/lis/v2/', '') for r in roles]
-
         email = decoded_token.get('email', None)
         name = decoded_token.get('name', None)
         platform = decoded_token.get('https://purl.imsglobal.org/spec/lti/claim/tool_platform', {})
+        course_id = decoded_token.get('https://purl.imsglobal.org/spec/lti/claim/custom', {}).get('canvas_course_id', None)
+        deployment_id = decoded_token.get('https://purl.imsglobal.org/spec/lti/claim/deployment_id', None)
+        group_id = f'{deployment_id}-{course_id}'
 
         # Find the Cognito user corresponding to the email address. Create a new user if user doesn't exist
         user = lookup_or_create_user(email)
@@ -137,8 +139,11 @@ async def lti_redirect(
             "email": email,
             "name": name,
             "roles": roles,
-            "context": context,
             "platform": platform,
+            "deploymentId": deployment_id,
+            "courseName": course_name,
+            "courseId": course_id,
+            "groupId": group_id,
         }
 
         import urllib.parse

--- a/frontend/src/pages/LtiLaunch.tsx
+++ b/frontend/src/pages/LtiLaunch.tsx
@@ -61,6 +61,16 @@ const LtiLaunch: React.FC = () => {
         setLtiSession(queryParamsObject);
         const _email = queryParamsObject?.email;
 
+        // Store the query params in local storage 
+        localStorage.setItem('ltiSession', JSON.stringify(queryParamsObject))
+        // set individual keys for every query param
+        if (queryParamsObject) {
+          console.log('setting indiviudal keys')
+          Object.keys(queryParamsObject).forEach((key) => {
+            localStorage.setItem(key, queryParamsObject[key]);
+          });
+        }
+
         if (_email === null) {
           setPageState(PageState.ERROR);
         } else if (_username === '') {
@@ -127,7 +137,7 @@ const LtiLaunch: React.FC = () => {
     if (action === null) return;
 
     // schedule a call to nextStep.action after few seconds 
-    console.log(`Run ${action} Take next step after 3 second`);
+    console.log(`Waiting 3 seconds ..`);
     const timer = setTimeout(() => {
       action();
     }, 3000);


### PR DESCRIPTION
Passing some additional query params from JWT token to the frontend. Canvas developer key needs to be configured to provide custom claims with course id.

Frontend code now saves the query params in local storage. Previous commits use groupId from localstorage to set the current course for the user. I verified that backend queries are picking up the new groupId instead of the hard-coded value.