### PR TITLE
Fix issue in KB update of bot owned by another user

### DIFF
--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -96,13 +96,14 @@ DEFAULT_GENERATION_CONFIG = (
 
 def _update_s3_documents_by_diff(
     user_id: str,
+    creator_id: str,
     bot_id: str,
     added_filenames: list[str],
     deleted_filenames: list[str],
 ):
     for filename in added_filenames:
         tmp_path = compose_upload_temp_s3_path(user_id, bot_id, filename)
-        document_path = compose_upload_document_s3_path(user_id, bot_id, filename)
+        document_path = compose_upload_document_s3_path(creator_id, bot_id, filename)
         move_file_in_s3(DOCUMENT_BUCKET, tmp_path, document_path)
 
     for filename in deleted_filenames:
@@ -148,7 +149,7 @@ def create_new_bot(user_id: str, bot_input: BotInput) -> BotOutput:
     if filenames:
         try:
             # Move files from temp to final S3 path
-            _update_s3_documents_by_diff(user_id, bot_input.id, filenames, [])
+            _update_s3_documents_by_diff(user_id, user_id, bot_input.id, filenames, [])
             # Clean up any leftover temp uploads
             delete_files_with_prefix_from_s3(
                 DOCUMENT_BUCKET, compose_upload_temp_s3_prefix(user_id, bot_input.id)
@@ -347,6 +348,7 @@ def modify_owned_bot(
 
         # Commit changes to S3
         _update_s3_documents_by_diff(
+            user_id,
             creator_id,
             bot_id,
             modify_input.knowledge.added_filenames,


### PR DESCRIPTION
Fix document path handling for shared bots

- Added creator_id parameter to update_s3_documents_by_diff function to properly handle S3 paths
- Modified S3 document paths to use creator_id instead of user_id for correct document storage
- Updated function calls to pass both user_id and creator_id where needed
- Ensures documents in shared bots are properly stored and accessed under the creator's path