### PR TITLE
Fix for Prod-demo deployment failure with props.database.grantStreamR…

### DIFF
--- a/cdk/lib/constructs/embedding.ts
+++ b/cdk/lib/constructs/embedding.ts
@@ -571,7 +571,18 @@ export class Embedding extends Construct {
         resources: ["arn:aws:logs:*:*:*"],
       })
     )
-    props.database.grantStreamRead(removeHandlerRole);
+    removeHandlerRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          "dynamodb:DescribeStream",
+          "dynamodb:GetRecords",
+          "dynamodb:GetShardIterator",
+          "dynamodb:ListStreams",
+        ],
+        resources: [props.database.tableStreamArn!],
+      })
+    );
     props.documentBucket.grantReadWrite(removeHandlerRole);
 
     this._removalHandler = new DockerImageFunction(this, "BotRemovalHandler", {


### PR DESCRIPTION

In cdk/lib/bedrock-chat-stack.ts, you correctly instantiate the Database construct.
In cdk/lib/constructs/database.ts, the ConversationTable is created with stream: StreamViewType.NEW_IMAGE. This is correct and enables the stream.
In cdk/lib/constructs/embedding.ts, within the setupRemovalHandler method, the line props.database.grantStreamRead(removeHandlerRole); is called.

The error Attribute 'StreamArn' does not exist occurs because the tableStreamArn property of the database.table object might not be available at the exact moment grantStreamRead is called during the CDK synthesis process, even though the stream is configured correctly. CDK resolves resource properties like ARNs as tokens, and sometimes dependency ordering can cause issues with high-level grant methods.

We can fix this by explicitly adding the necessary IAM policy statement for stream access instead of using the grantStreamRead convenience method. This gives CDK a clearer dependency path.
I will modify the setupRemovalHandler method in cdk/lib/constructs/embedding.ts.

I've replaced the props.database.grantStreamRead(removeHandlerRole); line in cdk/lib/constructs/embedding.ts with an explicit IAM policy statement. This directly grants the necessary permissions (dynamodb:DescribeStream, dynamodb:GetRecords, dynamodb:GetShardIterator, dynamodb:ListStreams) to the removeHandlerRole using the props.database.tableStreamArn.

This approach often helps resolve CDK synthesis timing issues where the stream ARN token might not be fully resolved when the high-level grantStreamRead method is called.